### PR TITLE
FIXED: Flip bug

### DIFF
--- a/source/assets/scripts/card.js
+++ b/source/assets/scripts/card.js
@@ -91,13 +91,11 @@ class WorkoutCard extends HTMLElement {
   set disableFlip(val) {
     this._disableFlip = val;
     if (val) {
-      // Selection mode: always show workout (face up)
-      this._articleEl.classList.toggle("flipped");
+      // Selection mode: flipping is disabled, show default cursor
       this._articleEl.style.cursor = "default";
     } else {
-      // Browsing: allow flipping, start face up (workout showing)
+      // Flipping is enabled, show pointer cursor
       this._articleEl.style.cursor = "pointer";
-      this._articleEl.classList.toggle("flipped");
     }
   }
 }

--- a/source/assets/scripts/create-deck.js
+++ b/source/assets/scripts/create-deck.js
@@ -108,6 +108,21 @@ function unselectCards() {
  */
 function setCardsDisableFlip(disable) {
   document.querySelectorAll("workout-card").forEach((card) => {
+    if (disable) {
+      // Save current flip state and force face up
+      card._wasFlipped = card._articleEl.classList.contains("flipped");
+      card._articleEl.classList.remove("flipped");
+    } else {
+      // Restore previous flip state if it exists
+      if ('_wasFlipped' in card) {
+        if (card._wasFlipped) {
+          card._articleEl.classList.add("flipped");
+        } else {
+          card._articleEl.classList.remove("flipped");
+        }
+        delete card._wasFlipped;
+      }
+    }
     card.disableFlip = disable;
   });
 }


### PR DESCRIPTION
# Description

I noticed that whenever you went on select mode ALL CARDS would get flipped (regardless of them being flipped already; so, I went ahead and added some "memory" so that after leaving select mode users can see cards as they left them before entering select mode.

This should be fixed, check out video to see if you agree and like with this implementation, if so feel free to merge

### Only first 30 seconds (I forgot video was running lol)
[Video](https://drive.google.com/file/d/1MBqwCxgTdfscT-PukUc7QTQrebjZFnm-/view?usp=sharing)