### PR TITLE
group deck creation buttons together

### DIFF
--- a/source/assets/scripts/filter-control.js
+++ b/source/assets/scripts/filter-control.js
@@ -41,8 +41,8 @@ export function initFiltering(workouts) {
 
     // ─── 3. Toolbar  ────────────────────────────
     const toolbar = buildToolbar(muscles);
-    const cardsArea = document.querySelector('.cards-area');
-    cardsArea.insertBefore(toolbar, cardsArea.firstChild);
+    const controlsToolbar = document.querySelector('.controls-toolbar');
+    controlsToolbar.insertBefore(toolbar, controlsToolbar.firstChild);
 
     // ─── 4. Restore saved filter state and apply  ─────────────────
     restoreSelections(toolbar);

--- a/source/assets/styles/create-deck-styles.css
+++ b/source/assets/styles/create-deck-styles.css
@@ -152,13 +152,11 @@ button {
   transition: background-color 0.2s ease;
 }
 
-.create-deck {
-  position: fixed;
-  left: 50%;
-  bottom: 2rem;
-  transform: translateX(-50%);
-  margin: 0;
-  z-index: 100;
+.controls-toolbar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
 }
 
 button:hover {

--- a/source/create-deck.html
+++ b/source/create-deck.html
@@ -19,7 +19,6 @@
         <h1 class="app-name">SweatDeck</h1>
       </div>
       <div class="buttons">
-        <button id="selectorOn">Select Cards</button>
         <button
           class="view-decks"
           onclick="window.location.href='../index.html'"
@@ -33,10 +32,13 @@
       <h2>Choose some cards!</h2>
     
       <section class="cards-area">
-        <!-- JS will insert the toolbar here -->
+        <div class="controls-toolbar">
+          <!-- The filter toolbar will be inserted here by JS -->
+          <button id="selectorOn">Select Cards</button>
+          <button id="create-deck-button" class="create-deck">Create Deck</button>
+        </div>
         <div class="cards-container"></div>
       </section>
-      <button id="create-deck-button" class="create-deck">Create Deck</button>
       <p id="create-deck-error" class="error-message hidden"></p>
       <!--The container for cards-->
     </main>


### PR DESCRIPTION
moved "select cards" button from header to main body, to be grouped with filter dropdown and "create deck" button to aid with #40 
- in the future keep the options stickied to the page (like in Sam's implementation)